### PR TITLE
set user "vmail" as owner of doevcot stats writer

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,7 @@
     - 10-ssl.conf
     - 20-imap.conf
     - 90-quota.conf
+    - 90-stats.conf
   notify: restart dovecot
 
 - name: configure mail_crypt

--- a/templates/90-stats.conf.j2
+++ b/templates/90-stats.conf.j2
@@ -13,4 +13,3 @@ unix_listener stats-writer {
         mode = 0660
     }
 }
-

--- a/templates/90-stats.conf.j2
+++ b/templates/90-stats.conf.j2
@@ -1,0 +1,16 @@
+# get rid of postfix/pipe "Error: net_connect_unix(/var/run/dovecot/stats-writer) fa))"
+
+service stats {
+    unix_listener stats-reader {
+        user = vmail
+        group = vmail
+        mode = 0660
+    }
+
+unix_listener stats-writer {
+        user = vmail
+        group = vmail
+        mode = 0660
+    }
+}
+


### PR DESCRIPTION
On buster I ran in the problem, that postfix running as user "vmail" was not allowed to write to dovecot stats socket. Log msg and solution are same as here:

https://git.ispconfig.org/ispconfig/ispconfig3/issues/5343

I tried this on my system for a couple of days and the error message didn't show up again.