### PR TITLE
Set `dovecot_sieve_redirect_envelope_from` to `orig_recipient`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ dovecot_junk_trash_autoexpunge: 30d
 dovecot_sieve_location: "file:/var/vmail/%d/%n/sieve;active=/var/vmail/%d/%n/.dovecot.sieve"
 dovecot_sieve_before: /etc/dovecot/sieve-before/spam-to-junk.sieve
 dovecot_sieve_max_redirects: 20
+dovecot_sieve_redirect_envelope_from: orig_recipient
 
 # See https://wiki.dovecot.org/LoginProcess for performance tuning
 dovecot_login_service_count: 1

--- a/templates/90-sieve.conf.j2
+++ b/templates/90-sieve.conf.j2
@@ -169,7 +169,7 @@ plugin {
   #
   # This setting is ignored when the envelope sender is "<>". In that case the
   # sender of the redirected message is also always "<>".
-  #sieve_redirect_envelope_from = sender
+  sieve_redirect_envelope_from = {{ dovecot_sieve_redirect_envelope_from }}
 
   ## TRACE DEBUGGING
   # Trace debugging provides detailed insight in the operations performed by


### PR DESCRIPTION
This makes mail redirects via sieve filter SPF compliant.