### PR TITLE
Drop obsolete handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Restart opendkim
-  ansible.builtin.service:
-    name: opendkim
-    state: restarted
-
 - name: Restart dovecot
   ansible.builtin.service:
     name: dovecot
@@ -13,20 +8,6 @@
   ansible.builtin.service:
     name: dovecot
     state: reloaded
-
-- name: Restart rbldnsd
-  ansible.builtin.service:
-    name: rbldnsd
-    state: restarted
-
-- name: Rehash transport # noqa no-changed-when
-  ansible.builtin.command: /usr/sbin/postmap /etc/postfix/transport
-
-- name: Rehash tor transport map # noqa no-changed-when
-  ansible.builtin.command: /usr/sbin/postmap /etc/postfix/tor_transport
-
-- name: Rehash dnsbl reply map # noqa no-changed-when
-  ansible.builtin.command: /usr/sbin/postmap /etc/postfix/dnsbl-reply-map
 
 - name: Reload systemd
   ansible.builtin.systemd:


### PR DESCRIPTION
These were added via 14b9ee5ea8b648c84189324076e336e6b1dc10e3 but never used.

Besides, all of them deal with software not related to Dovecot.