### PR TITLE
Handle connection limits, by remote IP

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,10 @@ dovecot_default_client_limit: 10000
 dovecot_mail_max_userip_connections: 10
 dovecot_auth_worker_user: root
 
+# dovecot_remote_connections:
+#   "127.0.0.1":
+#     mail_max_userip_connections: 150
+
 dovecot_service_process_min_avail: "{{ ansible_processor_cores * ansible_processor_count }}"
 dovecot_service_restart_request_count: 1024
 

--- a/templates/20-imap.conf.j2
+++ b/templates/20-imap.conf.j2
@@ -118,3 +118,14 @@ protocol imap {
 # Maximum number of IMAP connections allowed for a user from each IP address.
 # NOTE: The username is compared case-sensitively.
 mail_max_userip_connections = {{ dovecot_mail_max_userip_connections }}
+
+# Remote specific overrides
+{% if dovecot_remote_connections | default({}) %}
+{% for ip, settings in dovecot_remote_connections.items() %}
+remote {{ ip }} {
+  {% for key, value in settings.items() %}
+  {{ key }} = {{ value }}
+  {% endfor %}
+}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This allows to override the global default connection limits, for example to apply different limits to a webmail server.